### PR TITLE
Add custom alarm message trait

### DIFF
--- a/src/main/scala/fr/acinq/alarmbot/CustomAlarmBotMessage.scala
+++ b/src/main/scala/fr/acinq/alarmbot/CustomAlarmBotMessage.scala
@@ -6,7 +6,7 @@ package fr.acinq.alarmbot
  * (2) Extend this trait, implement methods and broadcast when needed
  * (3) Alarmbot will catch your custom message and send it to TG
  */
-trait CustomAlarmMessage {
+trait CustomAlarmBotMessage {
   def senderEntity: String
   def message: String
 }

--- a/src/main/scala/fr/acinq/alarmbot/CustomAlarmMessage.scala
+++ b/src/main/scala/fr/acinq/alarmbot/CustomAlarmMessage.scala
@@ -1,0 +1,12 @@
+package fr.acinq.alarmbot
+
+/**
+ * Should be extended by other plugins to get their messages sent to TG through this plugin
+ * (1) Include Alarmbot plugin (this one) in your own plugin dependencies
+ * (2) Extend this trait, implement methods and broadcast when needed
+ * (3) Alarmbot will catch your custom message and send it to TG
+ */
+trait CustomAlarmMessage {
+  def senderEntity: String
+  def message: String
+}

--- a/src/main/scala/fr/acinq/alarmbot/WatchdogSync.scala
+++ b/src/main/scala/fr/acinq/alarmbot/WatchdogSync.scala
@@ -25,7 +25,7 @@ trait Messenger {
 }
 
 class WatchdogSync(kit: Kit, setup: Setup) extends DiagnosticActorLogging with Messenger {
-  context.system.eventStream.subscribe(channel = classOf[CustomAlarmMessage], subscriber = self)
+  context.system.eventStream.subscribe(channel = classOf[CustomAlarmBotMessage], subscriber = self)
   context.system.eventStream.subscribe(channel = classOf[DangerousBlocksSkew], subscriber = self)
   context.system.eventStream.subscribe(channel = classOf[ChannelStateChanged], subscriber = self)
   context.system.eventStream.subscribe(channel = classOf[ChannelClosed], subscriber = self)
@@ -48,7 +48,7 @@ class WatchdogSync(kit: Kit, setup: Setup) extends DiagnosticActorLogging with M
     case _: DangerousBlocksSkew =>
       sendMessage("Received a *DangerousBlocksSkew* event!")
 
-    case msg: CustomAlarmMessage =>
+    case msg: CustomAlarmBotMessage =>
       sendMessage(s"*${msg.senderEntity}*: ${msg.message}")
   }
 }

--- a/src/main/scala/fr/acinq/alarmbot/WatchdogSync.scala
+++ b/src/main/scala/fr/acinq/alarmbot/WatchdogSync.scala
@@ -49,6 +49,6 @@ class WatchdogSync(kit: Kit, setup: Setup) extends DiagnosticActorLogging with M
       sendMessage("Received a *DangerousBlocksSkew* event!")
 
     case msg: CustomAlarmMessage =>
-      sendMessage(s"*${msg.senderEntity}*: *${msg.message}*")
+      sendMessage(s"*${msg.senderEntity}*: ${msg.message}")
   }
 }

--- a/src/main/scala/fr/acinq/alarmbot/WatchdogSync.scala
+++ b/src/main/scala/fr/acinq/alarmbot/WatchdogSync.scala
@@ -6,7 +6,7 @@ import akka.actor.DiagnosticActorLogging
 import fr.acinq.eclair.{Kit, Setup}
 import fr.acinq.eclair.blockchain.watchdogs.BlockchainWatchdog.DangerousBlocksSkew
 import com.softwaremill.sttp.SttpBackend
-import fr.acinq.eclair.channel.{AbstractCommitments, ChannelClosed, ChannelStateChanged, Commitments, NORMAL, WAIT_FOR_FUNDING_LOCKED}
+import fr.acinq.eclair.channel.{ChannelClosed, ChannelStateChanged, NORMAL, WAIT_FOR_FUNDING_LOCKED}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -25,6 +25,7 @@ trait Messenger {
 }
 
 class WatchdogSync(kit: Kit, setup: Setup) extends DiagnosticActorLogging with Messenger {
+  context.system.eventStream.subscribe(channel = classOf[CustomAlarmMessage], subscriber = self)
   context.system.eventStream.subscribe(channel = classOf[DangerousBlocksSkew], subscriber = self)
   context.system.eventStream.subscribe(channel = classOf[ChannelStateChanged], subscriber = self)
   context.system.eventStream.subscribe(channel = classOf[ChannelClosed], subscriber = self)
@@ -45,6 +46,9 @@ class WatchdogSync(kit: Kit, setup: Setup) extends DiagnosticActorLogging with M
       sendMessage(s"Channel closed, channelId *$channelId*, closingType *${closingType.getClass.getName}*")
 
     case _: DangerousBlocksSkew =>
-      sendMessage("Node received a *DangerousBlocksSkew* event!")
+      sendMessage("Received a *DangerousBlocksSkew* event!")
+
+    case msg: CustomAlarmMessage =>
+      sendMessage(s"*${msg.senderEntity}*: *${msg.message}*")
   }
 }


### PR DESCRIPTION
This adds a `CustomAlarmMessage` trait which is supposed to be extended and broadcasted in other plugin implementations.

If some plugin wants to send its own custom messages to TG it should:

1. Include Alarmbot as dependency (so it has access to `CustomAlarmMessage` trait.)
2. Extend `CustomAlarmMessage` with concrete implementations sending plugin-specific messages.
3. Broadcast concrete implementations when needed.
4. When Eclair is started it should include both user plugin and Alarmbot.